### PR TITLE
Preserve module config when toggled

### DIFF
--- a/GameAssist
+++ b/GameAssist
@@ -122,7 +122,20 @@
         state[STATE_KEY][mod] = Object.assign(getState(mod), data);
     }
     function clearState(mod) {
-        if (state[STATE_KEY]?.[mod]) delete state[STATE_KEY][mod];
+        const root = state[STATE_KEY];
+        if (!root || !root[mod]) return;
+
+        const branch = root[mod];
+        if (!branch || typeof branch !== 'object') {
+            root[mod] = { config: {}, runtime: {} };
+            return;
+        }
+
+        if (typeof branch.config !== 'object' || branch.config === null) {
+            branch.config = {};
+        }
+
+        branch.runtime = {};
     }
 
     function auditState() {


### PR DESCRIPTION
## Summary
- adjust `clearState` so runtime data is reset without deleting stored module config, allowing toggles to retain options set via `!ga-config`

## Testing
- node - <<'NODE' (custom harness verifying config persistence when enabling/disabling modules)


------
https://chatgpt.com/codex/tasks/task_e_68ca0be19b10832ebd25ac6f2d9bc3f2