### PR TITLE
Improve module initialization error handling

### DIFF
--- a/GameAssist
+++ b/GameAssist
@@ -320,10 +320,21 @@
                 this.offEvents(name);
                 this.offCommands(name);
                 clearState(name);
-                getState(name).config.enabled = true;
-                m.initialized = true;
-                try { m.initFn(); this.log(name, 'Enabled'); }
-                catch(e) { this.handleError(name, e); }
+                const branch = getState(name);
+                try {
+                    m.initFn();
+                    m.initialized = true;
+                    branch.config.enabled = true;
+                    this.log(name, 'Enabled');
+                }
+                catch(e) {
+                    m.initialized = false;
+                    this.offEvents(name);
+                    this.offCommands(name);
+                    clearState(name);
+                    branch.config.enabled = false;
+                    this.handleError(name, e);
+                }
             });
         },
 
@@ -1243,10 +1254,20 @@ GameAssist.register('ConcentrationTracker', function() {
         GameAssist.log('Core', `GameAssist v${VERSION} ready; modules: ${Object.keys(MODULES).join(', ')}`);
 
         Object.entries(MODULES).forEach(([name, m]) => {
-            if (getState(name).config.enabled) {
-                m.initialized = true;
-                try { m.initFn(); }
-                catch(e) { GameAssist.handleError(name, e); }
+            const branch = getState(name);
+            if (branch.config.enabled) {
+                try {
+                    m.initFn();
+                    m.initialized = true;
+                }
+                catch(e) {
+                    m.initialized = false;
+                    GameAssist.offEvents(name);
+                    GameAssist.offCommands(name);
+                    clearState(name);
+                    branch.config.enabled = false;
+                    GameAssist.handleError(name, e);
+                }
             }
         });
     });


### PR DESCRIPTION
## Summary
- defer module initialized flags until after init functions succeed and persist enablement only on success
- ensure initialization failures reset initialized state, remove any partial handlers, and flip config.enabled back to false

## Testing
- node - <<'NODE' ... (custom harness simulating failing module initialization)


------
https://chatgpt.com/codex/tasks/task_e_68ca0df67708832e899b577405fc0f6f