### PR TITLE
Ensure modules remain disabled after failed init

### DIFF
--- a/GameAssist
+++ b/GameAssist
@@ -323,16 +323,17 @@
                 const branch = getState(name);
                 try {
                     m.initFn();
+                    // Mark initialized only after initFn completes successfully.
                     m.initialized = true;
                     branch.config.enabled = true;
                     this.log(name, 'Enabled');
                 }
                 catch(e) {
                     m.initialized = false;
+                    branch.config.enabled = false;
                     this.offEvents(name);
                     this.offCommands(name);
                     clearState(name);
-                    branch.config.enabled = false;
                     this.handleError(name, e);
                 }
             });
@@ -1258,14 +1259,15 @@ GameAssist.register('ConcentrationTracker', function() {
             if (branch.config.enabled) {
                 try {
                     m.initFn();
+                    // Mark initialized only after initFn completes successfully.
                     m.initialized = true;
                 }
                 catch(e) {
                     m.initialized = false;
+                    branch.config.enabled = false;
                     GameAssist.offEvents(name);
                     GameAssist.offCommands(name);
                     clearState(name);
-                    branch.config.enabled = false;
                     GameAssist.handleError(name, e);
                 }
             }


### PR DESCRIPTION
## Summary
- clarify that modules only flip their initialized flag once their `initFn` completes successfully
- reset the module's config before rolling back listeners when initialization fails to keep it disabled for retries

## Testing
- node - <<'NODE' … (custom harness to simulate a failing module initialization)


------
https://chatgpt.com/codex/tasks/task_e_68ca1552a570832e8c0b45e75df508d3