### PR TITLE
Add auto HP rolling for new NPC tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
   - Added `GameAssist` line 836: `GameAssist.getLinkedCharacter = getLinkedCharacter;` for public access.
   - Added module usages at `GameAssist` lines 1213, 1261, 1540, 1611, 1783, 1839, and 1886 so NPCManager, ConcentrationTracker, and NPCHPRoller consistently gate work on verified tokens.
   - Removed the per-module inline checks from the prior implementation: `GameAssist` (pre-update) line 1156 `const charId = token.get('represents');`, line 1168 `const character = getObj('character', charId);`, and line 1362 `const charId = token.get('represents');`, which duplicated validation logic.
+- NPCHPRoller can now auto-roll HP when new NPC tokens are created on the map (opt-in via `autoRollOnAdd`).
+  - Added `GameAssist` lines 1801-1869 to reuse a shared NPC context resolver, allowing the module to silently skip non-NPC tokens when listening for `add:graphic` events and annotate auto rolls in the log output.
+  - Added `GameAssist` lines 1948-1956 to register the `add:graphic` listener in the module metadata.
+  - Updated documentation (`README.md` §6.4 and §9) to describe the new opt-in behavior and configuration default.
 
 ### Changed
 - Core handler lifecycle now relies on module guard flags instead of physical `off()` calls.

--- a/GameAssist
+++ b/GameAssist
@@ -1798,17 +1798,23 @@ GameAssist.register('ConcentrationTracker', function() {
             return rollDice(count, sides) + bonus;
         }
 
-        function rollTokenHP(token) {
+        function resolveNpcContext(token, { logWarnings = true } = {}) {
             if (!token) {
-                GameAssist.log('NPCHPRoller', 'Token not found', 'WARN');
-                return;
+                if (logWarnings) {
+                    GameAssist.log('NPCHPRoller', 'Token not found', 'WARN');
+                }
+                return null;
             }
 
             const linked = GameAssist.getLinkedCharacter(token);
             if (!linked) {
-                GameAssist.log('NPCHPRoller', `${token.get('name') || 'Token'} must be linked to a character on the Objects layer.`, 'WARN');
-                return;
+                if (logWarnings) {
+                    GameAssist.log('NPCHPRoller', `${token.get('name') || 'Token'} must be linked to a character on the Objects layer.`, 'WARN');
+                }
+                return null;
             }
+
+            const displayName = token.get('name') || linked.character.get('name') || 'Token';
 
             const npcAttr = findObjs({
                 _type: 'attribute',
@@ -1817,8 +1823,10 @@ GameAssist.register('ConcentrationTracker', function() {
             })[0];
 
             if (!npcAttr || npcAttr.get('current') !== '1') {
-                GameAssist.log('NPCHPRoller', `${token.get('name') || linked.character.get('name')} is not flagged as an NPC.`, 'WARN');
-                return;
+                if (logWarnings) {
+                    GameAssist.log('NPCHPRoller', `${displayName} is not flagged as an NPC.`, 'WARN');
+                }
+                return null;
             }
 
             const hpFormulaAttr = findObjs({
@@ -1828,24 +1836,37 @@ GameAssist.register('ConcentrationTracker', function() {
             })[0];
 
             if (!hpFormulaAttr) {
-                GameAssist.log('NPCHPRoller', `No HP formula found for ${token.get('name') || linked.character.get('name')}`, 'WARN');
-                return;
+                if (logWarnings) {
+                    GameAssist.log('NPCHPRoller', `No HP formula found for ${displayName}`, 'WARN');
+                }
+                return null;
             }
 
             const formula = hpFormulaAttr.get('current');
             const diceData = parseDiceString(formula);
 
             if (!diceData) {
-                GameAssist.log('NPCHPRoller', `Invalid HP formula: ${formula}`, 'WARN');
-                return;
+                if (logWarnings) {
+                    GameAssist.log('NPCHPRoller', `Invalid HP formula: ${formula}`, 'WARN');
+                }
+                return null;
             }
 
-            const hp = rollHP(diceData);
+            return { linked, formula, diceData, displayName };
+        }
+
+        function rollTokenHP(token, { logWarnings = true, reason = 'manual' } = {}) {
+            const context = resolveNpcContext(token, { logWarnings });
+            if (!context) return false;
+
+            const hp = rollHP(context.diceData);
 
             token.set('bar1_value', hp);
             token.set('bar1_max', hp);
 
-            GameAssist.log('NPCHPRoller', `${token.get('name')} HP set to ${hp} using [${formula}]`);
+            const suffix = reason === 'auto' ? ' (auto-roll on add)' : '';
+            GameAssist.log('NPCHPRoller', `${context.displayName} HP set to ${hp} using [${context.formula}]${suffix}`);
+            return true;
         }
 
         GameAssist.onCommand('!npc-hp-all', async msg => {
@@ -1924,11 +1945,16 @@ GameAssist.register('ConcentrationTracker', function() {
             }
         }, 'NPCHPRoller', { gmOnly: true });
 
+        GameAssist.onEvent('add:graphic', token => {
+            if (!modState.config.autoRollOnAdd) return;
+            rollTokenHP(token, { logWarnings: false, reason: 'auto' });
+        }, 'NPCHPRoller');
+
         GameAssist.log('NPCHPRoller', 'v0.1.1.0 Ready: !npc-hp-all, !npc-hp-selected', 'INFO', { startup: true });
-    }, { 
-        enabled: true, 
-        events: [], 
-        prefixes: ['!npc-hp-all', '!npc-hp-selected'] 
+    }, {
+        enabled: true,
+        events: ['add:graphic'],
+        prefixes: ['!npc-hp-all', '!npc-hp-selected']
     });
     // --- Notes & Comments ---
     // CHOICE: Use Math.random for simplicity; acceptable for non‑critical HP rolls.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Watches `change:graphic:bar1_value`. When an NPC’s HP drops below 1 the `deadM
 
 *(Requires TokenMod API for automated marker/status integration.)*
 
-`!npc-hp-all` rolls HP for every NPC on the player page; `!npc-hp-selected` works on a token-selection. Parses any `NdM±K` formula stored in `npc_hpformula`. Optional future flag `autoRollOnAdd` (present but currently false by default as it is a work in progress).
+`!npc-hp-all` rolls HP for every NPC on the player page; `!npc-hp-selected` works on a token-selection. Parses any `NdM±K` formula stored in `npc_hpformula`. Enable `autoRollOnAdd` (`!ga-config set NPCHPRoller autoRollOnAdd=true`) to have GameAssist automatically roll HP the instant a qualifying NPC token is dropped onto the map.
 
 ---
 
@@ -182,7 +182,7 @@ VI. To verify end-to-end, type `!ga-status` as GM. You’ll receive a whispered 
 |                          | `randomize`      | bool   | `true`            |
 | **NPCManager**           | `autoTrackDeath` | bool   | `true`            |
 |                          | `deadMarker`     | string | `"dead"`          |
-| **NPCHPRoller**          | `autoRollOnAdd`  | bool   | `false` (future)  |
+| **NPCHPRoller**          | `autoRollOnAdd`  | bool   | `false` (opt-in)  |
 
 ---
 


### PR DESCRIPTION
## Summary
- add an NPC token context resolver so NPCHPRoller can reuse validation and annotate auto rolls
- hook NPCHPRoller into add:graphic to auto-roll HP when autoRollOnAdd is enabled
- document the new behavior and configuration in the README and changelog

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ca597a5cc4832eae29245db567de46