### PR TITLE
Expand named and behavioral conflict metadata

### DIFF
--- a/script.json
+++ b/script.json
@@ -39,7 +39,10 @@
     "Concentration",
     "DeathTracker",
     "MonsterHitDice",
-    "5th Edition OGL by Roll20 Companion"
+    "5th Edition OGL by Roll20 Companion",
+    "Other scripts that modify NPC HP or use bar1_value",
+    "Other scripts that automatically add or remove the same death or concentration status markers",
+    "Other scripts that automatically process natural 1 attack rolls or open critical-fumble menus"
   ],
   "commands": [
     "!ga-status",

--- a/script.json
+++ b/script.json
@@ -38,7 +38,8 @@
   "conflicts": [
     "Concentration",
     "DeathTracker",
-    "Other scripts that modify NPC HP or use bar1_value"
+    "MonsterHitDice",
+    "5th Edition OGL by Roll20 Companion"
   ],
   "commands": [
     "!ga-status",


### PR DESCRIPTION
## Summary

- Preserve the existing `Concentration` and `DeathTracker` conflict entries.
- Add `MonsterHitDice` and `5th Edition OGL by Roll20 Companion` as concrete Roll20 scripts that can overlap with GameAssist's NPC hit-point automation.
- Retain plain-language conflict categories so DMs are warned about private, renamed, custom, or unlisted scripts that operate on the same campaign data.
- Cover the three relevant ownership areas: NPC HP/bar 1, death and concentration markers, and automatic natural-1 handling.

## Why

Concrete script names help identify known One-Click conflicts, but names alone cannot cover private scripts, campaign-specific utilities, renamed copies, or scripts that are not in the public Roll20 library. The behavioral entries tell a DM what kind of overlap to look for without requiring them to know a script's implementation.

These are feature-level conflicts rather than universal incompatibilities. Scripts can remain installed when only one enabled tool owns the overlapping behavior.

## Resulting conflict guidance

- `Concentration`
- `DeathTracker`
- `MonsterHitDice`
- `5th Edition OGL by Roll20 Companion`
- Other scripts that modify NPC HP or use `bar1_value`
- Other scripts that automatically add or remove the same death or concentration status markers
- Other scripts that automatically process natural 1 attack rolls or open critical-fumble menus

## Audit notes

The public Roll20 library was also checked for adjacent tools:

- `Aura/Tint HealthColors` may observe the same HP bar and manage a dead marker, but its visual-health behavior can coexist when marker ownership is configured deliberately.
- `Combat Master` can manage conditions, but does not inherently duplicate GameAssist's concentration workflow.
- `StatusInfo` remains an intended optional companion.
- `Fumbler` and `Improved Critical` use separate manual commands and do not inherently duplicate GameAssist's automatic natural-1 listener.

## Validation

- `script.json` parses successfully.
- The manifest remains at v0.1.4.7 with `GameAssist.js` and 58 command entries.
- The branch changes only `script.json`.
- No runtime behavior changes.